### PR TITLE
ci: add one-click Cloud Run deploy button

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,12 @@ RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries && \
     echo 'Acquire::http::Timeout "60";' >> /etc/apt/apt.conf.d/80-retries && \
     echo 'Acquire::https::Timeout "60";' >> /etc/apt/apt.conf.d/80-retries
 
+# Byt archive.ubuntu.com → mirrors.ubuntu.com (auto-väljer närmaste spegel).
+# Cloud Build us-central1 kan inte alltid nå archive.ubuntu.com direkt, så
+# mirror+-schemat ger apt en lista att prova i turordning.
+RUN sed -i 's|http://archive.ubuntu.com/ubuntu/|mirror+http://mirrors.ubuntu.com/mirrors.txt|g' \
+    /etc/apt/sources.list.d/ubuntu.sources
+
 RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing \
     curl ca-certificates \
     pkg-config libssl-dev python3 \
@@ -79,6 +85,12 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries && \
     echo 'Acquire::http::Timeout "60";' >> /etc/apt/apt.conf.d/80-retries && \
     echo 'Acquire::https::Timeout "60";' >> /etc/apt/apt.conf.d/80-retries
+
+# Byt archive.ubuntu.com → mirrors.ubuntu.com (auto-väljer närmaste spegel).
+# Cloud Build us-central1 kan inte alltid nå archive.ubuntu.com direkt, så
+# mirror+-schemat ger apt en lista att prova i turordning.
+RUN sed -i 's|http://archive.ubuntu.com/ubuntu/|mirror+http://mirrors.ubuntu.com/mirrors.txt|g' \
+    /etc/apt/sources.list.d/ubuntu.sources
 
 RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing \
     ca-certificates \

--- a/Dockerfile
+++ b/Dockerfile
@@ -137,6 +137,20 @@ ENV VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.x86_64.json
 COPY --from=builder /app/target/server-release/aether-server /usr/local/bin/aether-server
 COPY --from=builder /app/target/server-release/aether-mcp /usr/local/bin/aether-mcp
 
+# ── Litestream för kontinuerlig SQLite-replikering till GCS ──────────────────
+# Cloud Run har ephemeral disk — containers kan dödas när som helst. Litestream
+# streamar varje WAL-write till en GCS-bucket så DB:n överlever restarts.
+# Sätt LITESTREAM_BUCKET env-var i Cloud Run för att aktivera; lämna tomt för
+# att köra utan persistens (t.ex. lokalt).
+ARG LITESTREAM_VERSION=0.3.13
+RUN curl -fsSL "https://github.com/benbjohnson/litestream/releases/download/v${LITESTREAM_VERSION}/litestream-v${LITESTREAM_VERSION}-linux-amd64.tar.gz" \
+      | tar -xz -C /usr/local/bin litestream \
+    && chmod +x /usr/local/bin/litestream
+
+COPY litestream.yml /etc/litestream.yml
+COPY scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
 # ── Static HTML assets (served from disk at runtime) ─────────────────────────
 # Changes to these files do NOT trigger Rust recompilation — only this layer
 # is rebuilt, which takes seconds instead of minutes.
@@ -161,4 +175,4 @@ EXPOSE 10000
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
     CMD curl -f http://localhost:10000/health || exit 1
 
-CMD ["aether-server"]
+CMD ["/usr/local/bin/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,12 @@ FROM ubuntu:24.04 AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# apt-retries: härdar builds mot tillfälliga nätfel (Cloud Build / Render)
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries && \
+    echo 'Acquire::http::Timeout "60";' >> /etc/apt/apt.conf.d/80-retries && \
+    echo 'Acquire::https::Timeout "60";' >> /etc/apt/apt.conf.d/80-retries
+
+RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing \
     curl ca-certificates \
     pkg-config libssl-dev python3 \
     # Blitz rendering deps: fontconfig for font discovery + mesa for wgpu software backend
@@ -70,7 +75,12 @@ FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# apt-retries: härdar builds mot tillfälliga nätfel (Cloud Build / Render)
+RUN echo 'Acquire::Retries "5";' > /etc/apt/apt.conf.d/80-retries && \
+    echo 'Acquire::http::Timeout "60";' >> /etc/apt/apt.conf.d/80-retries && \
+    echo 'Acquire::https::Timeout "60";' >> /etc/apt/apt.conf.d/80-retries
+
+RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing \
     ca-certificates \
     python3-minimal \
     # Fonts for Blitz rendering (system fallback fonts)

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,18 +85,27 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libegl-mesa0 \
     libgbm1 \
     mesa-vulkan-drivers \
-    # curl for health checks
-    curl \
-    # Chromium for Tier 2 CDP rendering (headless Chrome screenshots)
-    chromium-browser \
+    # curl for health checks and adding Google apt key
+    curl gnupg \
     # ORT (ONNX Runtime) kräver libstdc++ vid runtime
     libstdc++6 \
     fontconfig \
+    && rm -rf /var/lib/apt/lists/*
+
+# Google Chrome stable för Tier 2 CDP rendering.
+# På Ubuntu 24.04 är `chromium-browser` bara en snap-stub som inte fungerar i
+# containrar, så vi installerar Chrome direkt från Googles officiella apt-repo.
+RUN curl -fsSL https://dl.google.com/linux/linux_signing_key.pub \
+      | gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg \
+    && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main" \
+      > /etc/apt/sources.list.d/google-chrome.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends google-chrome-stable \
     && rm -rf /var/lib/apt/lists/* \
     && fc-cache -fv
 
-# Chromium sökväg för headless_chrome crate
-ENV CHROME_PATH=/usr/bin/chromium-browser
+# Chrome sökväg för headless_chrome crate
+ENV CHROME_PATH=/usr/bin/google-chrome
 # Force wgpu to use software Vulkan (lavapipe) — no GPU needed
 # Lavapipe provides a full Vulkan 1.3 adapter via mesa
 ENV WGPU_BACKEND=vulkan

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@
   <a href="https://render.com/deploy?repo=https://github.com/robinandreeklund-collab/AetherAgent">
     <img src="https://render.com/images/deploy-to-render-button.svg" alt="Deploy to Render">
   </a>
+  &nbsp;
+  <a href="https://deploy.cloud.run/?git_repo=https://github.com/robinandreeklund-collab/AetherAgent">
+    <img src="https://deploy.cloud.run/button.svg" alt="Run on Google Cloud">
+  </a>
 </p>
 
 ---

--- a/app.json
+++ b/app.json
@@ -7,7 +7,7 @@
       "required": true
     },
     "CHROME_PATH": {
-      "value": "/usr/bin/chromium-browser",
+      "value": "/usr/bin/google-chrome",
       "required": true
     },
     "AETHER_MODEL_URL": {

--- a/app.json
+++ b/app.json
@@ -1,0 +1,36 @@
+{
+  "name": "AetherAgent",
+  "description": "LLM-native embeddable browser engine in Rust — semantic perception + prompt injection protection for AI agents.",
+  "env": {
+    "PORT": {
+      "value": "10000",
+      "required": true
+    },
+    "CHROME_PATH": {
+      "value": "/usr/bin/chromium-browser",
+      "required": true
+    },
+    "AETHER_MODEL_URL": {
+      "description": "Public URL to the YOLOv8-nano ONNX model (e.g. a GitHub Release asset). Leave blank to disable vision features.",
+      "required": false
+    },
+    "RUST_LOG": {
+      "value": "info",
+      "required": true
+    }
+  },
+  "options": {
+    "allow-unauthenticated": true,
+    "memory": "2Gi",
+    "cpu": "2",
+    "port": 10000,
+    "http2": false,
+    "concurrency": 40,
+    "max-instances": 3
+  },
+  "hooks": {
+    "postcreate": {
+      "commands": []
+    }
+  }
+}

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,64 @@
+# Cloud Build pipeline: bygger Docker-image, pushar till Artifact Registry,
+# och deployar till Cloud Run. Kör med:
+#
+#   gcloud builds submit --config=cloudbuild.yaml --region=us-central1
+#
+# Första bygget tar ~15-25 min (all Rust-kompilering); efterföljande byggen
+# återanvänder Docker-layer-cachen och blir betydligt snabbare.
+
+timeout: 3600s
+
+options:
+  # 8 vCPU, 32 GB RAM — default (1 vCPU) orkar inte kompilera ~300 Rust-deps
+  # inom 1 h. Med E2_HIGHCPU_8 tar bygget ~15-25 min istället för 45-60+ min.
+  machineType: E2_HIGHCPU_8
+  # Större disk för target/-mappen (Rust-kompilering genererar mycket)
+  diskSizeGb: 100
+  logging: CLOUD_LOGGING_ONLY
+
+substitutions:
+  _REGION: us-central1
+  _REPO: cloud-run-source-deploy
+  _SERVICE: aetheragent
+  _IMAGE: ${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO}/${_SERVICE}:${SHORT_SHA}
+
+steps:
+  # 1. Bygg Docker-image (Dockerfile i repo-roten)
+  - name: gcr.io/cloud-builders/docker
+    id: build
+    args:
+      - build
+      - --tag=${_IMAGE}
+      - --tag=${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO}/${_SERVICE}:latest
+      - .
+
+  # 2. Pusha imagen till Artifact Registry
+  - name: gcr.io/cloud-builders/docker
+    id: push
+    args:
+      - push
+      - --all-tags
+      - ${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO}/${_SERVICE}
+
+  # 3. Deploya till Cloud Run
+  - name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    id: deploy
+    entrypoint: gcloud
+    args:
+      - run
+      - deploy
+      - ${_SERVICE}
+      - --image=${_IMAGE}
+      - --region=${_REGION}
+      - --platform=managed
+      - --allow-unauthenticated
+      - --memory=2Gi
+      - --cpu=2
+      - --port=10000
+      - --concurrency=40
+      - --max-instances=3
+      - --set-env-vars=RUST_LOG=info,CHROME_PATH=/usr/bin/google-chrome
+
+images:
+  - ${_IMAGE}
+  - ${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO}/${_SERVICE}:latest

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -20,6 +20,9 @@ substitutions:
   _REGION: us-central1
   _REPO: cloud-run-source-deploy
   _SERVICE: aetheragent
+  # GCS-bucket för Litestream SQLite-replikering. Lämna tomt för ingen persistens.
+  # Skapa bucket med: gcloud storage buckets create gs://<name> --location=${_REGION}
+  _LITESTREAM_BUCKET: ''
 
 steps:
   # 1. Bygg Docker-image (Dockerfile i repo-roten)
@@ -56,7 +59,7 @@ steps:
       - --port=10000
       - --concurrency=40
       - --max-instances=3
-      - --set-env-vars=RUST_LOG=info,CHROME_PATH=/usr/bin/google-chrome
+      - --set-env-vars=RUST_LOG=info,CHROME_PATH=/usr/bin/google-chrome,LITESTREAM_BUCKET=${_LITESTREAM_BUCKET}
 
 images:
   - ${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO}/${_SERVICE}:${BUILD_ID}

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -20,7 +20,6 @@ substitutions:
   _REGION: us-central1
   _REPO: cloud-run-source-deploy
   _SERVICE: aetheragent
-  _IMAGE: ${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO}/${_SERVICE}:${SHORT_SHA}
 
 steps:
   # 1. Bygg Docker-image (Dockerfile i repo-roten)
@@ -28,7 +27,7 @@ steps:
     id: build
     args:
       - build
-      - --tag=${_IMAGE}
+      - --tag=${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO}/${_SERVICE}:${BUILD_ID}
       - --tag=${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO}/${_SERVICE}:latest
       - .
 
@@ -48,7 +47,7 @@ steps:
       - run
       - deploy
       - ${_SERVICE}
-      - --image=${_IMAGE}
+      - --image=${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO}/${_SERVICE}:${BUILD_ID}
       - --region=${_REGION}
       - --platform=managed
       - --allow-unauthenticated
@@ -60,5 +59,5 @@ steps:
       - --set-env-vars=RUST_LOG=info,CHROME_PATH=/usr/bin/google-chrome
 
 images:
-  - ${_IMAGE}
+  - ${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO}/${_SERVICE}:${BUILD_ID}
   - ${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO}/${_SERVICE}:latest

--- a/litestream.yml
+++ b/litestream.yml
@@ -1,0 +1,13 @@
+dbs:
+  - path: /data/aether.db
+    replicas:
+      - type: gcs
+        bucket: ${LITESTREAM_BUCKET}
+        path: aether.db
+        # Sync-intervall: streamar WAL var 1 s till GCS.
+        # Vid container-death förlorar vi max 1 s data.
+        sync-interval: 1s
+        # Kvarhåll 24 h av snapshots — räcker för att rulla tillbaka vid felaktig deploy.
+        retention: 24h
+        # Ta nytt snapshot var 6:e h för snabbare restore.
+        snapshot-interval: 6h

--- a/render.yaml
+++ b/render.yaml
@@ -12,7 +12,7 @@ services:
         value: "10000"
       # Chromium sökväg (satt i Dockerfile men explicit här för tydlighet)
       - key: CHROME_PATH
-        value: /usr/bin/chromium-browser
+        value: /usr/bin/google-chrome
       # YOLOv8-nano ONNX-modell — sätt URL i Render Dashboard efter model-upload
       - key: AETHER_MODEL_URL
         sync: false

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Entrypoint som:
+#   1. Försöker restore:a /data/aether.db från GCS via Litestream (om LITESTREAM_BUCKET satt)
+#   2. Kör aether-server under Litestreams replicate-supervisor
+#      — Litestream streamar WAL-ändringar till GCS kontinuerligt.
+#   Om LITESTREAM_BUCKET inte är satt kör vi servern direkt (ephemeral storage).
+
+set -eu
+
+mkdir -p /data
+
+if [ -n "${LITESTREAM_BUCKET:-}" ]; then
+    echo "[litestream] bucket=${LITESTREAM_BUCKET}"
+
+    # Restore om DB saknas lokalt och replica finns i GCS.
+    # -if-db-not-exists: ingen overwrite av ev. befintlig lokal DB.
+    # -if-replica-exists: ingen panik om bucket är tom (första starten).
+    litestream restore \
+        -if-db-not-exists \
+        -if-replica-exists \
+        -config /etc/litestream.yml \
+        /data/aether.db || echo "[litestream] restore skipped (no replica or local db exists)"
+
+    # Starta litestream replicate som parent-process och exec servern via -exec.
+    # Litestream vidarebefordrar signaler till servern och flushar WAL vid shutdown.
+    exec litestream replicate -config /etc/litestream.yml -exec "aether-server"
+else
+    echo "[litestream] LITESTREAM_BUCKET not set — running without persistence replication"
+    exec aether-server
+fi


### PR DESCRIPTION
Mirrors the existing Render deploy button. Uses Google's Cloud Run Button (deploy.cloud.run) which opens Cloud Shell, builds the Dockerfile, and deploys to Cloud Run. Config lives in app.json (2 GiB RAM + 2 vCPU to fit Chromium + ORT + Blitz, port 10000, AETHER_MODEL_URL prompted on deploy).